### PR TITLE
panel: don't become for local tasks

### DIFF
--- a/roles/pterodactyl_panel/tasks/get_version.yml
+++ b/roles/pterodactyl_panel/tasks/get_version.yml
@@ -5,6 +5,7 @@
     return_content: yes
   register: pterodactyl_panel_latest_release
   delegate_to: localhost
+  become: no
   retries: 3
   delay: 5
   check_mode: no


### PR DESCRIPTION
When we `delegate_to: localhost`, we should explicitly set `become` to `false`, as we may not have privilege escalation capabilities on the localhost. Tasks such as performing a URL query are not affected by privileges anyways. 