### PR TITLE
Update supported distributions, drop Ubuntu 18.04,

### DIFF
--- a/roles/pterodactyl_panel/README.md
+++ b/roles/pterodactyl_panel/README.md
@@ -16,24 +16,24 @@ There's a few things this role does *NOT* do, namely:
 - Install a PHP version other than the one that comes with your OS
 - Allow using a Webserver other than Apache
 
-## Versioning Policy
+## Supported Distributions and Panel Versions
 
-This role officially supports the Pterodactyl 1.x series releases.
-We test against the latest version, as well as the last versions to support older PHP releases.
+This role officially supports the Pterodactyl 1.x series of releases.
+We officially support the following distributions and releases:
+
+| Distribution | PHP Version | Supported Panel Release | Note |
+|--------------|-------------|-------------------------|------|
+| Ubuntu 22.04 LTS | `8.1` | `latest` | |
+| Ubuntu 20.04 LTS | `7.4` | `<=1.10.x` | `1.10` releases are the last to support PHP 7 |
+| Debian 12 | `8.2` |`latest` | |
+| Debian 11 | `7.4` |`<=1.10.x` | `1.10` releases are the last to support PHP 7 |
+
 Other versions are supported on a best-effort basis.
 
 ## Requirements
 
 - You need to supply your own MariaDB/MySQL database. See the role vars below for available parameters
 - This role requires root access. Make sure it is run with `become: true` or equivalent
-
-### Distribution and PHP
-
-This role supports Debian-based distributions shipping the required apache packages.
-Your chosen distro needs to ship with a version of PHP that is compatible with the `pterodactyl_panel_version`.
-See the [Pterodactyl Upgrade docs](https://pterodactyl.io/panel/1.0/updating.html) for details.
-You can find out which version of PHP ships with which distribution [here](https://pkgs.org/download/libapache2-mod-php).
-ure to run this role with `become: yes` or equivalent
 
 ## Role Variables
 

--- a/roles/pterodactyl_panel/molecule/default/molecule.yml
+++ b/roles/pterodactyl_panel/molecule/default/molecule.yml
@@ -1,45 +1,13 @@
 ---
 platforms:
-  - name: pterodactyl-panel-ubuntu-20-db
-    image: docker.io/mariadb
-    pre_build_image: true
-    override_command: false
-    env:
-      MYSQL_ROOT_PASSWORD: panel_molecule
-      MYSQL_DATABASE: panel_molecule
-      MYSQL_USER: panel_molecule
-      MYSQL_PASSWORD: panel_molecule
-    network: molecule-pterodactyl-panel
-  - name: pterodactyl-panel-ubuntu-20
-    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+  - name: pterodactyl-panel-ubuntu-22
+    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
     groups:
       - panel
-      - php7
     systemd: always
     override_command: false
     pre_build_image: true
     network: molecule-pterodactyl-panel
-
-  - name: pterodactyl-panel-debian-11-db
-    image: docker.io/mariadb
-    pre_build_image: true
-    override_command: false
-    env:
-      MYSQL_ROOT_PASSWORD: panel_molecule
-      MYSQL_DATABASE: panel_molecule
-      MYSQL_USER: panel_molecule
-      MYSQL_PASSWORD: panel_molecule
-    network: molecule-pterodactyl-panel
-  - name: pterodactyl-panel-debian-11
-    image: "docker.io/geerlingguy/docker-debian11-ansible"
-    groups:
-      - panel
-      - php7
-    systemd: always
-    override_command: false
-    pre_build_image: true
-    network: molecule-pterodactyl-panel
-
   - name: pterodactyl-panel-ubuntu-22-db
     image: docker.io/mariadb
     pre_build_image: true
@@ -50,13 +18,64 @@ platforms:
       MYSQL_USER: panel_molecule
       MYSQL_PASSWORD: panel_molecule
     network: molecule-pterodactyl-panel
-  - name: pterodactyl-panel-ubuntu-22
-    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
+
+  - name: pterodactyl-panel-ubuntu-20
+    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+    groups:
+      - panel
+      - php7
+    systemd: always
+    override_command: false
+    pre_build_image: true
+    network: molecule-pterodactyl-panel
+  - name: pterodactyl-panel-ubuntu-20-db
+    image: docker.io/mariadb
+    pre_build_image: true
+    override_command: false
+    env:
+      MYSQL_ROOT_PASSWORD: panel_molecule
+      MYSQL_DATABASE: panel_molecule
+      MYSQL_USER: panel_molecule
+      MYSQL_PASSWORD: panel_molecule
+    network: molecule-pterodactyl-panel
+
+  - name: pterodactyl-panel-debian-12
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     groups:
       - panel
     systemd: always
     override_command: false
     pre_build_image: true
+    network: molecule-pterodactyl-panel
+  - name: pterodactyl-panel-debian-12-db
+    image: docker.io/mariadb
+    pre_build_image: true
+    override_command: false
+    env:
+      MYSQL_ROOT_PASSWORD: panel_molecule
+      MYSQL_DATABASE: panel_molecule
+      MYSQL_USER: panel_molecule
+      MYSQL_PASSWORD: panel_molecule
+    network: molecule-pterodactyl-panel
+
+  - name: pterodactyl-panel-debian-11
+    image: "docker.io/geerlingguy/docker-debian11-ansible"
+    groups:
+      - panel
+      - php7
+    systemd: always
+    override_command: false
+    pre_build_image: true
+    network: molecule-pterodactyl-panel
+  - name: pterodactyl-panel-debian-11-db
+    image: docker.io/mariadb
+    pre_build_image: true
+    override_command: false
+    env:
+      MYSQL_ROOT_PASSWORD: panel_molecule
+      MYSQL_DATABASE: panel_molecule
+      MYSQL_USER: panel_molecule
+      MYSQL_PASSWORD: panel_molecule
     network: molecule-pterodactyl-panel
 
 provisioner:

--- a/roles/pterodactyl_panel/molecule/selfsign/molecule.yml
+++ b/roles/pterodactyl_panel/molecule/selfsign/molecule.yml
@@ -1,45 +1,13 @@
 ---
 platforms:
-  - name: pterodactyl-panel-ubuntu-20-db
-    image: docker.io/mariadb
-    pre_build_image: true
-    override_command: false
-    env:
-      MYSQL_ROOT_PASSWORD: panel_molecule
-      MYSQL_DATABASE: panel_molecule
-      MYSQL_USER: panel_molecule
-      MYSQL_PASSWORD: panel_molecule
-    network: molecule-pterodactyl-panel
-  - name: pterodactyl-panel-ubuntu-20
-    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+  - name: pterodactyl-panel-ubuntu-22
+    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
     groups:
       - panel
-      - php7
     systemd: always
     override_command: false
     pre_build_image: true
     network: molecule-pterodactyl-panel
-
-  - name: pterodactyl-panel-debian-11-db
-    image: docker.io/mariadb
-    pre_build_image: true
-    override_command: false
-    env:
-      MYSQL_ROOT_PASSWORD: panel_molecule
-      MYSQL_DATABASE: panel_molecule
-      MYSQL_USER: panel_molecule
-      MYSQL_PASSWORD: panel_molecule
-    network: molecule-pterodactyl-panel
-  - name: pterodactyl-panel-debian-11
-    image: "docker.io/geerlingguy/docker-debian11-ansible"
-    groups:
-      - panel
-      - php7
-    systemd: always
-    override_command: false
-    pre_build_image: true
-    network: molecule-pterodactyl-panel
-
   - name: pterodactyl-panel-ubuntu-22-db
     image: docker.io/mariadb
     pre_build_image: true
@@ -50,13 +18,64 @@ platforms:
       MYSQL_USER: panel_molecule
       MYSQL_PASSWORD: panel_molecule
     network: molecule-pterodactyl-panel
-  - name: pterodactyl-panel-ubuntu-22
-    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
+
+  - name: pterodactyl-panel-ubuntu-20
+    image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
+    groups:
+      - panel
+      - php7
+    systemd: always
+    override_command: false
+    pre_build_image: true
+    network: molecule-pterodactyl-panel
+  - name: pterodactyl-panel-ubuntu-20-db
+    image: docker.io/mariadb
+    pre_build_image: true
+    override_command: false
+    env:
+      MYSQL_ROOT_PASSWORD: panel_molecule
+      MYSQL_DATABASE: panel_molecule
+      MYSQL_USER: panel_molecule
+      MYSQL_PASSWORD: panel_molecule
+    network: molecule-pterodactyl-panel
+
+  - name: pterodactyl-panel-debian-12
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     groups:
       - panel
     systemd: always
     override_command: false
     pre_build_image: true
+    network: molecule-pterodactyl-panel
+  - name: pterodactyl-panel-debian-12-db
+    image: docker.io/mariadb
+    pre_build_image: true
+    override_command: false
+    env:
+      MYSQL_ROOT_PASSWORD: panel_molecule
+      MYSQL_DATABASE: panel_molecule
+      MYSQL_USER: panel_molecule
+      MYSQL_PASSWORD: panel_molecule
+    network: molecule-pterodactyl-panel
+
+  - name: pterodactyl-panel-debian-11
+    image: "docker.io/geerlingguy/docker-debian11-ansible"
+    groups:
+      - panel
+      - php7
+    systemd: always
+    override_command: false
+    pre_build_image: true
+    network: molecule-pterodactyl-panel
+  - name: pterodactyl-panel-debian-11-db
+    image: docker.io/mariadb
+    pre_build_image: true
+    override_command: false
+    env:
+      MYSQL_ROOT_PASSWORD: panel_molecule
+      MYSQL_DATABASE: panel_molecule
+      MYSQL_USER: panel_molecule
+      MYSQL_PASSWORD: panel_molecule
     network: molecule-pterodactyl-panel
 
 provisioner:

--- a/roles/pterodactyl_wings/README.md
+++ b/roles/pterodactyl_wings/README.md
@@ -12,8 +12,8 @@ Older versions are supported on a best-effort basis.
 ## Requirements
 
 - The following distributions are currently supported:
-  - Ubuntu 18.04 LTS or newer
-  - Newer debian distros should work too
+  - Ubuntu: 20.04 LTS, 22.04 LTS
+  - Debian: 10, 11, 12
 - This role requires root access. Make sure to run this role with `become: yes` or equivalent
 - Docker is required to run Wings. If docker is not present, this role will install it automatically
 - You must have already created a new node in your panel.

--- a/roles/pterodactyl_wings/molecule/default/molecule.yml
+++ b/roles/pterodactyl_wings/molecule/default/molecule.yml
@@ -1,5 +1,18 @@
 ---
 platforms:
+  - name: pterodactyl-wings-ubuntu-22
+    image: "docker.io/geerlingguy/docker-ubuntu2204-ansible"
+    volumes:
+      # The wings daemon needs to connect to a docker/podman daemon. We use a sibling setup
+      # to allow the wings containers to access the host docker daemon by passing through the docker socket
+      - /var/run/podman/podman.sock:/tmp/podman.sock
+    env:
+      # The /tmp/sock workaround is required due to this issue: https://github.com/ansible-community/molecule/issues/1568
+      DOCKER_HOST: /tmp/podman.sock
+    systemd: always
+    override_command: false
+    pre_build_image: true
+
   - name: pterodactyl-wings-ubuntu-20
     image: "docker.io/geerlingguy/docker-ubuntu2004-ansible"
     volumes:
@@ -13,8 +26,8 @@ platforms:
     override_command: false
     pre_build_image: true
 
-  - name: pterodactyl-wings-ubuntu-18
-    image: "docker.io/geerlingguy/docker-ubuntu1804-ansible"
+  - name: pterodactyl-wings-debian-12
+    image: "docker.io/geerlingguy/docker-debian12-ansible"
     volumes:
       - /var/run/podman/podman.sock:/tmp/podman.sock
     env:
@@ -25,6 +38,16 @@ platforms:
 
   - name: pterodactyl-wings-debian-11
     image: "docker.io/geerlingguy/docker-debian11-ansible"
+    volumes:
+      - /var/run/podman/podman.sock:/tmp/podman.sock
+    env:
+      DOCKER_HOST: /tmp/podman.sock
+    systemd: always
+    override_command: false
+    pre_build_image: true
+
+  - name: pterodactyl-wings-debian-10
+    image: "docker.io/geerlingguy/docker-debian10-ansible"
     volumes:
       - /var/run/podman/podman.sock:/tmp/podman.sock
     env:


### PR DESCRIPTION
This patch clarifies the supported distributions on both roles and updates the distribution versions.

As Ubuntu 18.04 has reached its end of main support life, we drop it from the molecule tests. Debian 12 has also been added 