### PR TITLE
panel: add pterodactyl_panel_environment_only var

### DIFF
--- a/roles/pterodactyl_panel/README.md
+++ b/roles/pterodactyl_panel/README.md
@@ -155,6 +155,14 @@ Prefix for all options: `pterodactyl_panel_admin_`
 - `pterodactyl_panel_aws_backups_bucket: ""`
 
 
+#### Other
+
+##### `pterodactyl_panel_environment_only`
+- If set to `false`, allow admins to change `.env` file settings from the admin UI.
+- Please note that changing settings this way is **NOT** supported by this role and may cause issues.
+- It is recommended that you leave this setting on `true` unless you know what you are doing
+- Default: `true`
+
 ## Example Playbooks
 
 See the main [README](https://github.com/maxhoesel-ansible/ansible-collection-pterodactyl#installing-the-panel) for a more detailed example.

--- a/roles/pterodactyl_panel/defaults/main.yml
+++ b/roles/pterodactyl_panel/defaults/main.yml
@@ -15,6 +15,7 @@ pterodactyl_panel_timezone: America/New_York
 pterodactyl_panel_locale: en
 pterodactyl_panel_egg_author: "no-reply@{{ pterodactyl_panel_domain }}"
 pterodactyl_panel_url: "https://{{ ansible_fqdn }}"
+pterodactyl_panel_environment_only: true
 
 pterodactyl_panel_db_host: "127.0.0.1"
 pterodactyl_panel_db_port: 3306

--- a/roles/pterodactyl_panel/templates/env.j2
+++ b/roles/pterodactyl_panel/templates/env.j2
@@ -5,7 +5,7 @@ APP_THEME=pterodactyl
 APP_TIMEZONE={{ pterodactyl_panel_timezone | quote }}
 APP_CLEAR_TASKLOG=720
 APP_DELETE_MINUTES=10
-APP_ENVIRONMENT_ONLY=true
+APP_ENVIRONMENT_ONLY={{ pterodactyl_panel_environment_only }}
 LOG_CHANNEL=daily
 APP_LOCALE={{ pterodactyl_panel_locale | quote }}
 
@@ -41,8 +41,6 @@ REDIS_PORT=6379
 QUEUE_HIGH=high
 QUEUE_STANDARD=standard
 QUEUE_LOW=low
-
-APP_ENVIRONMENT_ONLY=false
 
 {% if pterodactyl_panel_backup_enable %}
 APP_BACKUP_DRIVER={{ pterodactyl_panel_backup_driver | quote }}


### PR DESCRIPTION
This patch fixes an ambiguity in the default .env config file by removing a duplicate entry and adds a `pterodactyl_panel_environment_only` variable so that users can configure whether to allow modifications to the settings through the admin UI. Since enabling this feature would allow for configuration drift, it is disabled by default