### PR TITLE
wings: loosen systemd restart interval

### DIFF
--- a/roles/pterodactyl_wings/templates/wings.service.j2
+++ b/roles/pterodactyl_wings/templates/wings.service.j2
@@ -14,7 +14,9 @@ LimitNOFILE=4096
 PIDFile=/var/run/wings/daemon.pid
 ExecStart=/usr/local/bin/wings
 Restart=on-failure
-StartLimitInterval=600
+StartLimitInterval=180
+StartLimitBurst=30
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This updates the wings systemd unit to be in line with the officially recommended values 